### PR TITLE
Some fixes for delete all boons/traits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixes for delete all boons/traits, @zerp
+
 ## [0.11.7] - 2025-12-22
 
 - Add mouse scrolling for boon selector like pages

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -552,15 +552,19 @@ function mod.GetLootColorFromTrait(traitName)
 end
 
 function mod.RemoveAllTraits()
-	for i, traitData in pairs(CurrentRun.Hero.Traits) do
-		RemoveTrait(CurrentRun.Hero, traitData.Name)	
+	-- deep copy table since Hero.Traits table is modified during deletion
+	local traitCopy = game.DeepCopyTable(CurrentRun.Hero.Traits)
+	for i, traitData in pairs(traitCopy) do
+		RemoveTrait(CurrentRun.Hero, traitData.Name)
 	end
 end
 
 function mod.RemoveAllBoons()
-	for i, traitData in pairs(CurrentRun.Hero.Traits) do
-		-- Only remove boons
-		if traitData.RarityLevels ~= nil and traitData.Slot ~= "Keepsake" and traitData.Slot ~= "Aspect" and traitData.UpgradeResourceCost == nil then
+	-- deep copy table since Hero.Traits table is modified during deletion
+	local traitCopy = game.DeepCopyTable(CurrentRun.Hero.Traits)
+	for i, traitData in pairs(traitCopy) do
+		-- Only remove boons, if it can be in boon manager it can be deleted
+		if mod.IsBoonManagerValid(traitData.Name) then
 			RemoveTrait(CurrentRun.Hero, traitData.Name)
 		end
 	end


### PR DESCRIPTION
2 issues this fixes
- Delete all boons was also removing arcana traits.
- The deletion only deleted about half the boons due to the trait table being modified mid loop.

Fixed them by
- Using the boon manager population check instead of what was previously there.
- Deep copying the Hero.Traits table before looping.