### PR TITLE
Feature: Multiple Native UI Layout Save Slots

### DIFF
--- a/src/Data/ScreenData.lua
+++ b/src/Data/ScreenData.lua
@@ -674,6 +674,71 @@ function mod.setupScreenData()
 					}
 				},
 			}
+		},
+
+		StateSelector = {
+			Components = {},
+			OpenSound = "/SFX/Menu Sounds/HadesLocationTextAppear",
+			Name = "StateSelector",
+			RowStartX = -(ScreenCenterX * 0.65),
+			RowStartY = -(ScreenCenterY * 0.35),
+
+			ComponentData =
+			{
+				DefaultGroup = "Combat_Menu_TraitTray",
+				UseNativeScreenCenter = true,
+				Order = {
+					"BackgroundTint",
+					"Background"
+				},
+
+				BackgroundTint =
+				{
+					Graphic = "rectangle01",
+					GroupName = "Combat_Menu",
+					Scale = 10,
+					X = ScreenCenterX,
+					Y = ScreenCenterY,
+				},
+
+				Background =
+				{
+					Graphic = "Box_FullScreen",
+					GroupName = "Combat_Menu",
+					X = ScreenCenterX,
+					Y = ScreenCenterY,
+					Scale = 1.15,
+					Text = mod.Locale.SelectSlot,
+					TextArgs =
+					{
+						FontSize = 32,
+						Width = 750,
+						OffsetY = -(ScreenCenterY * 0.825),
+						Color = Color.White,
+						Font = "P22UndergroundSCHeavy",
+						ShadowBlur = 0,
+						ShadowColor = { 0, 0, 0, 0 },
+						ShadowOffset = { 0, 3 },
+					},
+
+					Children =
+					{
+						CloseButton =
+						{
+							Graphic = "ButtonClose",
+							GroupName = "Combat_Menu_TraitTray",
+							Scale = 0.7,
+							OffsetX = 0,
+							OffsetY = ScreenCenterY - 70,
+							Data =
+							{
+								OnPressedFunctionName = _PLUGIN.guid .. '.' .. 'CloseStateSelector',
+								ControlHotkeys = { "Cancel", },
+							},
+						},
+					}
+				},
+			}
 		}
 	})
 end
@@ -891,7 +956,7 @@ mod.CommandData = {
 		Name = mod.Locale.SaveStateTitle,
 		Description = mod.Locale.SaveStateDescription,
 		Type = "Command",
-		Function = _PLUGIN.guid .. '.' .. 'SaveState'
+		Function = _PLUGIN.guid .. '.' .. 'OpenStateSelectorSave'
 	},
 	{
 		IconPath = "GUI\\Shell\\CloudSuccess",
@@ -899,7 +964,7 @@ mod.CommandData = {
 		Name = mod.Locale.LoadStateTitle,
 		Description = mod.Locale.LoadStateDescription,
 		Type = "Command",
-		Function = _PLUGIN.guid .. '.' .. 'LoadState'
+		Function = _PLUGIN.guid .. '.' .. 'OpenStateSelectorLoad'
 	},
 }
 

--- a/src/Scripts/MenuScripts.lua
+++ b/src/Scripts/MenuScripts.lua
@@ -1769,3 +1769,209 @@ function mod.DoesPlayerHaveHex()
 end
 
 --#endregion
+
+--#region STATE SELECTOR
+
+function mod.OpenStateSelectorSave(screen, button)
+	if IsScreenOpen("StateSelector") then
+		return
+	end
+	mod.UpdateScreenData()
+
+	local screen = DeepCopyTable(ScreenData.StateSelector)
+	screen.Mode = "Save"
+	screen.FirstPage = 0
+	screen.LastPage = 0
+	screen.CurrentPage = screen.FirstPage
+	screen.AwaitingNameInputForSlot = nil
+	local components = screen.Components
+
+	OnScreenOpened(screen)
+	HideCombatUI(screen.Name)
+	CreateScreenFromData(screen, screen.ComponentData)
+
+	mod.StateSelectorLoadPage(screen)
+
+	SetColor({ Id = components.BackgroundTint.Id, Color = Color.Black })
+	SetAlpha({ Id = components.BackgroundTint.Id, Fraction = 0.0, Duration = 0 })
+	SetAlpha({ Id = components.BackgroundTint.Id, Fraction = 0.9, Duration = 0.3 })
+	wait(0.3)
+
+	SetConfigOption({ Name = "ExclusiveInteractGroup", Value = "Combat_Menu_TraitTray" })
+	screen.KeepOpen = true
+	
+	HandleScreenInput(screen)
+end
+
+function mod.OpenStateSelectorLoad(screen, button)
+	if IsScreenOpen("StateSelector") then
+		return
+	end
+	mod.UpdateScreenData()
+
+	local screen = DeepCopyTable(ScreenData.StateSelector)
+	screen.Mode = "Load"
+	screen.FirstPage = 0
+	screen.LastPage = 0
+	screen.CurrentPage = screen.FirstPage
+	local components = screen.Components
+
+	OnScreenOpened(screen)
+	HideCombatUI(screen.Name)
+	CreateScreenFromData(screen, screen.ComponentData)
+
+	mod.StateSelectorLoadPage(screen)
+
+	SetColor({ Id = components.BackgroundTint.Id, Color = Color.Black })
+	SetAlpha({ Id = components.BackgroundTint.Id, Fraction = 0.0, Duration = 0 })
+	SetAlpha({ Id = components.BackgroundTint.Id, Fraction = 0.9, Duration = 0.3 })
+	wait(0.3)
+
+	SetConfigOption({ Name = "ExclusiveInteractGroup", Value = "Combat_Menu_TraitTray" })
+	screen.KeepOpen = true
+	HandleScreenInput(screen)
+end
+
+function mod.CloseStateSelector(screen)
+	mod.AwaitingNameInputForSlot = nil
+	ShowCombatUI(screen.Name)
+	SetConfigOption({ Name = "ExclusiveInteractGroup", Value = nil })
+	OnScreenCloseStarted(screen)
+	CloseScreen(GetAllIds(screen.Components), 0.15)
+	OnScreenCloseFinished(screen)
+	notifyExistingWaiters("StateSelector")
+end
+
+function mod.StateSelectorLoadPage(screen)
+	local boonsPerRow = 4
+	local maxRows = 6
+	local maxSlots = boonsPerRow * maxRows
+	local columnOffset = 410
+	local rowOffset = 140
+
+	screen.RowStartX = -(columnOffset * (boonsPerRow - 1)) / 2
+	screen.RowStartY = -(rowOffset * (maxRows - 1)) / 2
+
+	if data.SavedStates == nil then
+		data.SavedStates = {}
+	end
+
+	for index = 1, maxSlots do
+		local rowIndex = math.floor((index - 1) / boonsPerRow)
+		local offsetX = screen.RowStartX + columnOffset * ((index - 1) % boonsPerRow)
+		local offsetY = screen.RowStartY + rowOffset * rowIndex
+		
+		local purchaseButtonKey = "SlotButton" .. index
+		screen.Components[purchaseButtonKey] = CreateScreenComponent({
+			Name = "ButtonDefault",
+			Group = "Combat_Menu_TraitTray",
+			ScaleX = 1.25,
+			ScaleY = 1.25,
+			ToDestroy = true
+		})
+		SetInteractProperty({
+			DestinationId = screen.Components[purchaseButtonKey].Id,
+			Property = "TooltipOffsetY",
+			Value = 100
+		})
+		
+		screen.Components[purchaseButtonKey].SlotIndex = index
+		if screen.Mode == "Save" then
+			screen.Components[purchaseButtonKey].OnPressedFunctionName = mod.TriggerSaveState
+		else
+			screen.Components[purchaseButtonKey].OnPressedFunctionName = mod.TriggerLoadState
+		end
+		
+		Attach({
+			Id = screen.Components[purchaseButtonKey].Id,
+			DestinationId = screen.Components.Background.Id,
+			OffsetX = offsetX,
+			OffsetY = offsetY
+		})
+		
+		local titleText = ""
+		local descText = ""
+		local textOffsetX = 0
+		local iconAnimation = nil
+
+		if data.SavedStates[index] ~= nil and data.SavedStates[index].Weapon ~= nil then
+			local saveObj = data.SavedStates[index]
+			
+			titleText = saveObj.Weapon or "UnknownWeapon"
+			
+			if saveObj.Aspect and saveObj.Aspect.Name then
+			    descText = saveObj.Aspect.Name
+			    if TraitData[saveObj.Aspect.Name] ~= nil and TraitData[saveObj.Aspect.Name].Icon ~= nil then
+			        iconAnimation = TraitData[saveObj.Aspect.Name].Icon
+			    end
+			end
+			
+			if iconAnimation then
+			    textOffsetX = 35
+			end
+		else
+		    titleText = mod.Locale.EmptySlot
+		end
+
+		CreateTextBox({
+			Id = screen.Components[purchaseButtonKey].Id,
+			Text = titleText,
+			FontSize = 20,
+			OffsetX = textOffsetX,
+			OffsetY = -15,
+			Color = Color.White,
+			Font = "P22UndergroundSCMedium",
+			ShadowBlur = 0,
+			ShadowColor = { 0, 0, 0, 1 },
+			ShadowOffset = { 0, 2 },
+			Justification = "Center"
+		})
+
+		CreateTextBox({
+			Id = screen.Components[purchaseButtonKey].Id,
+			Text = descText,
+			FontSize = 16,
+			OffsetX = textOffsetX,
+			OffsetY = 15,
+			Color = { 0.8, 0.8, 0.8, 1 },
+			Font = "P22UndergroundSCMedium",
+			ShadowBlur = 0,
+			ShadowColor = { 0, 0, 0, 1 },
+			ShadowOffset = { 0, 2 },
+			Justification = "Center"
+		})
+		
+		if iconAnimation then
+			local icon = {
+				Name = "BlankObstacle",
+				Animation = iconAnimation,
+				Scale = 0.35,
+				Group = "Combat_Menu_TraitTray",
+				ToDestroy = true
+			}
+			screen.Components[purchaseButtonKey .. "Icon"] = CreateScreenComponent(icon)
+			screen.Components[purchaseButtonKey].Icon = screen.Components[purchaseButtonKey .. "Icon"]
+			Attach({
+				Id = screen.Components[purchaseButtonKey .. "Icon"].Id,
+				DestinationId = screen.Components[purchaseButtonKey].Id,
+				OffsetX = -75,
+				OffsetY = -5
+			})
+		end
+	end
+end
+
+function mod.TriggerSaveState(screen, button)
+	mod.SaveState(button.SlotIndex)
+	mod.CloseStateSelector(screen)
+end
+
+function mod.TriggerLoadState(screen, button)
+	mod.LoadState(nil, button.SlotIndex)
+	mod.CloseStateSelector(screen)
+end
+
+--#endregion
+
+--#endregion
+

--- a/src/Text/en.lua
+++ b/src/Text/en.lua
@@ -44,6 +44,8 @@ public.AddLocale("en", {
 	SaveStateLoaded = "State loaded!",
 
 	ConsumableSelectorTitle = "Consumable Selector",
-	ConsumableSelectorDescription = "Give yourself any consumable item."
+	ConsumableSelectorDescription = "Give yourself any consumable item.",
 
+	SelectSlot = "Select Slot",
+	EmptySlot = "Empty",
 })

--- a/src/Text/zhCN.lua
+++ b/src/Text/zhCN.lua
@@ -44,5 +44,8 @@ public.AddLocale("zh-CN", {
 	SaveStateLoaded = "已加载套装!",
 
 	ConsumableSelectorTitle = "物品选择器",
-	ConsumableSelectorDescription = "立即获得任意卡戎物品及地图物品。"
+	ConsumableSelectorDescription = "立即获得任意卡戎物品及地图物品。",
+
+	SelectSlot = "选择套装",
+	EmptySlot = "空",
 })

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -21,6 +21,15 @@ ModUtil.LoadOnce(function()
 		rom.game.GameState.PonyMenu = { Data = {} }
 	end
 	data = rom.game.GameState.PonyMenu.Data
+
+	if data.SavedState ~= nil and data.SavedStates == nil then
+		data.SavedStates = {}
+		data.SavedStates[1] = data.SavedState
+		data.SavedState = nil
+	end
+	if data.SavedStates == nil then
+		data.SavedStates = {}
+	end
 end)
 
 function mod.GetLanguageString(path)
@@ -719,12 +728,14 @@ function mod.KillPlayer()
 	Kill(CurrentRun.Hero)
 end
 
-function mod.SaveState()
+function mod.SaveState(slotIndex)
+	slotIndex = slotIndex or 1
 	if CurrentRun.Hero.Traits ~= nil then
 		local wp = GetEquippedWeapon()
 		local aspect = GameState.LastWeaponUpgradeName[wp]
 		local aspectLevel = GetWeaponUpgradeLevel(aspect)
-		data.SavedState = {
+		
+		data.SavedStates[slotIndex] = {
 			Traits = {},
 			MetaUpgrades = {},
 			Weapon = wp,
@@ -734,22 +745,23 @@ function mod.SaveState()
 			Familiar = GameState.EquippedFamiliar,
 			Hex = nil
 		}
+		
 		for i, traitData in pairs(CurrentRun.Hero.Traits) do
 			if
 				not traitData.MetaUpgrade
-				and traitData.Name ~= data.SavedState.Weapon
-				and traitData.Name ~= data.SavedState.Aspect.Name
-				and traitData.Name ~= data.SavedState.Keepsake
-				and traitData.Name ~= data.SavedState.Assist
-				and traitData.Name ~= data.SavedState.Familiar
+				and traitData.Name ~= data.SavedStates[slotIndex].Weapon
+				and traitData.Name ~= data.SavedStates[slotIndex].Aspect.Name
+				and traitData.Name ~= data.SavedStates[slotIndex].Keepsake
+				and traitData.Name ~= data.SavedStates[slotIndex].Assist
+				and traitData.Name ~= data.SavedStates[slotIndex].Familiar
 			then
 				if traitData.Slot and traitData.Slot == "Spell" then
-					data.SavedState.Hex = traitData.Name
+					data.SavedStates[slotIndex].Hex = traitData.Name
 				else
-					table.insert(data.SavedState.Traits, { Name = traitData.Name, Rarity = traitData.Rarity, StackNum = traitData.StackNum })
+					table.insert(data.SavedStates[slotIndex].Traits, { Name = traitData.Name, Rarity = traitData.Rarity, StackNum = traitData.StackNum })
 				end
 			elseif traitData.MetaUpgrade then
-				table.insert(data.SavedState.MetaUpgrades, {
+				table.insert(data.SavedStates[slotIndex].MetaUpgrades, {
 					TraitName = traitData.Name,
 					Rarity = traitData.Rarity,
 					CustomMultiplier = traitData.CustomMultiplier,
@@ -771,36 +783,40 @@ function mod.SaveState()
 	end
 end
 
-function mod.LoadState(newRun)
-	if data.SavedState ~= nil then
-		if newRun == nil then
-			mod.RemoveAllTraits()
-			ClearUpgrades()
-		end
+function mod.LoadState(newRun, slotIndex)
+	slotIndex = slotIndex or 1
+	local stateData = data.SavedStates[slotIndex]
+	
+	if newRun == nil then
+		mod.RemoveAllTraits()
+		ClearUpgrades()
+	end
+	
+	if stateData ~= nil and stateData.Weapon ~= nil then
 		if GameState.LastAwardTrait == "ReincarnationKeepsake" then
 			RemoveLastStand(CurrentRun.Hero, "ReincarnationKeepsake")
 			CurrentRun.Hero.MaxLastStands = CurrentRun.Hero.MaxLastStands - 1
 		end
-		EquipPlayerWeapon(WeaponData[data.SavedState.Weapon], { LoadPackages = true })
-		if data.SavedState.Keepsake ~= nil then
-			EquipKeepsake(CurrentRun.Hero, data.SavedState.Keepsake, { FromLoot = true, SkipNewTraitHighlight = true })
+		EquipPlayerWeapon(WeaponData[stateData.Weapon], { LoadPackages = true })
+		if stateData.Keepsake ~= nil then
+			EquipKeepsake(CurrentRun.Hero, stateData.Keepsake, { FromLoot = true, SkipNewTraitHighlight = true })
 		end
-		if data.SavedState.Assist ~= nil then
-			EquipAssist(CurrentRun.Hero, data.SavedState.Assist, { SkipNewTraitHighlight = true })
+		if stateData.Assist ~= nil then
+			EquipAssist(CurrentRun.Hero, stateData.Assist, { SkipNewTraitHighlight = true })
 		end
-		if data.SavedState.Familiar ~= nil then
-			EquipFamiliar(nil, { Unit = CurrentRun.Hero, FamiliarName = data.SavedState.Familiar, SkipNewTraitHighlight = true })
+		if stateData.Familiar ~= nil then
+			EquipFamiliar(nil, { Unit = CurrentRun.Hero, FamiliarName = stateData.Familiar, SkipNewTraitHighlight = true })
 		end
-		if data.SavedState.Aspect.Name ~= nil then
+		if stateData.Aspect.Name ~= nil then
 			AddTraitToHero({
-				TraitName = data.SavedState.Aspect.Name,
-				Rarity = data.SavedState.Aspect.Rarity,
+				TraitName = stateData.Aspect.Name,
+				Rarity = stateData.Aspect.Rarity,
 				SkipNewTraitHighlight = true,
 				SkipQuestStatusCheck = true,
 				SkipActivatedTraitUpdate = true,
 			})
 		end
-		for _, traitData in pairs(data.SavedState.Traits) do
+		for _, traitData in pairs(stateData.Traits) do
 			AddTraitToHero({
 				TraitData = GetProcessedTraitData({
 					Unit = CurrentRun.Hero,
@@ -813,17 +829,17 @@ function mod.LoadState(newRun)
 				SkipActivatedTraitUpdate = true,
 			})
 		end
-		if data.SavedState.Hex ~= nil then
+		if stateData.Hex ~= nil then
 			AddTraitToHero({
-				TraitName = data.SavedState.Hex,
+				TraitName = stateData.Hex,
 				SkipNewTraitHighlight = true,
 				SkipQuestStatusCheck = true,
 				SkipActivatedTraitUpdate = true,
 			})
-			-- CurrentRun.Hero.SlottedSpell = DeepCopyTable(SpellData[data.SavedState.Hex])
-			-- CurrentRun.Hero.SlottedSpell.Talents = DeepCopyTable(CreateTalentTree(SpellData[data.SavedState.Hex]))
+			-- CurrentRun.Hero.SlottedSpell = DeepCopyTable(SpellData[stateData.Hex])
+			-- CurrentRun.Hero.SlottedSpell.Talents = DeepCopyTable(CreateTalentTree(SpellData[stateData.Hex]))
 		end
-		for _, traitData in pairs(data.SavedState.MetaUpgrades) do
+		for _, traitData in pairs(stateData.MetaUpgrades) do
 			AddTraitToHero({
 				SkipNewTraitHighlight = true,
 				SkipQuestStatusCheck = true,
@@ -834,18 +850,19 @@ function mod.LoadState(newRun)
 				SourceName = traitData.SourceName,
 			})
 		end
-		if newRun == nil then
-			PlaySound({ Name = "/SFX/WrathEndingWarning", Id = CurrentRun.Hero.ObjectId })
-			thread(InCombatTextArgs,
-				{
-					TargetId = CurrentRun.Hero.ObjectId,
-					Text = mod.Locale.SaveStateLoaded,
-					SkipRise = false,
-					SkipFlash = false,
-					Duration = 1.5,
-					ShadowScaleX = 1.5,
-				})
-		end
+	end
+	
+	if newRun == nil then
+		PlaySound({ Name = "/SFX/WrathEndingWarning", Id = CurrentRun.Hero.ObjectId })
+		thread(InCombatTextArgs,
+			{
+				TargetId = CurrentRun.Hero.ObjectId,
+				Text = mod.Locale.SaveStateLoaded,
+				SkipRise = false,
+				SkipFlash = false,
+				Duration = 1.5,
+				ShadowScaleX = 1.5,
+			})
 	end
 end
 

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -648,6 +648,7 @@ function CreateNewCustomRun(room)
 	-- EquipFamiliar(nil, { Unit = CurrentRun.Hero, FamiliarName = GameState.EquippedFamiliar, SkipNewTraitHighlight = true })
 	-- EquipWeaponUpgrade(CurrentRun.Hero, { SkipNewTraitHighlight = true })
 	-- EquipMetaUpgrades(CurrentRun.Hero, { SkipNewTraitHighlight = true })
+	InitHeroLastStands(CurrentRun.Hero)
 	mod.LoadState(true)
 	UpdateRunHistoryCache(CurrentRun)
 
@@ -662,8 +663,6 @@ function CreateNewCustomRun(room)
 	if ConfigOptionCache.EasyMode then
 		CurrentRun.EasyModeLevel = GameState.EasyModeLevel
 	end
-
-	InitHeroLastStands(CurrentRun.Hero)
 
 	InitializeRewardStores(CurrentRun)
 	--SelectBannedEliteAttributes( CurrentRun )
@@ -743,23 +742,23 @@ function mod.SaveState(slotIndex)
 			Keepsake = GameState.LastAwardTrait,
 			Assist = GameState.LastAssistTrait,
 			Familiar = GameState.EquippedFamiliar,
-			Hex = nil
+			Hex = nil,
+			LastStands = nil
 		}
 		
 		for i, traitData in pairs(CurrentRun.Hero.Traits) do
-			if
+			if traitData.Slot and traitData.Slot == "Familiar" then
+				-- Skip, familiar is handled separately
+			elseif traitData.Slot and traitData.Slot == "Spell" then
+				-- Skip, Hex is handled separately
+			elseif
 				not traitData.MetaUpgrade
 				and traitData.Name ~= data.SavedStates[slotIndex].Weapon
 				and traitData.Name ~= data.SavedStates[slotIndex].Aspect.Name
 				and traitData.Name ~= data.SavedStates[slotIndex].Keepsake
 				and traitData.Name ~= data.SavedStates[slotIndex].Assist
-				and traitData.Name ~= data.SavedStates[slotIndex].Familiar
 			then
-				if traitData.Slot and traitData.Slot == "Spell" then
-					data.SavedStates[slotIndex].Hex = traitData.Name
-				else
-					table.insert(data.SavedStates[slotIndex].Traits, { Name = traitData.Name, Rarity = traitData.Rarity, StackNum = traitData.StackNum })
-				end
+				table.insert(data.SavedStates[slotIndex].Traits, { Name = traitData.Name, Rarity = traitData.Rarity, StackNum = traitData.StackNum })
 			elseif traitData.MetaUpgrade then
 				table.insert(data.SavedStates[slotIndex].MetaUpgrades, {
 					TraitName = traitData.Name,
@@ -768,6 +767,13 @@ function mod.SaveState(slotIndex)
 					SourceName = traitData.Name
 				})
 			end
+		end
+
+		if CurrentRun.Hero.SlottedSpell ~= nil then
+			data.SavedStates[slotIndex].Hex = DeepCopyTable(CurrentRun.Hero.SlottedSpell)
+		end
+		if CurrentRun.Hero.LastStands ~= nil then
+			data.SavedStates[slotIndex].LastStands = DeepCopyTable(CurrentRun.Hero.LastStands)
 		end
 		SaveCheckpoint({ DevSaveName = CreateDevSaveName(CurrentRun) })
 		PlaySound({ Name = "/SFX/WrathEndingWarning", Id = CurrentRun.Hero.ObjectId })
@@ -830,14 +836,28 @@ function mod.LoadState(newRun, slotIndex)
 			})
 		end
 		if stateData.Hex ~= nil then
-			AddTraitToHero({
-				TraitName = stateData.Hex,
-				SkipNewTraitHighlight = true,
-				SkipQuestStatusCheck = true,
-				SkipActivatedTraitUpdate = true,
-			})
-			-- CurrentRun.Hero.SlottedSpell = DeepCopyTable(SpellData[stateData.Hex])
-			-- CurrentRun.Hero.SlottedSpell.Talents = DeepCopyTable(CreateTalentTree(SpellData[stateData.Hex]))
+			if type(stateData.Hex) == "table" then
+				AddTraitToHero({
+					TraitName = stateData.Hex.TraitName,
+					SkipNewTraitHighlight = true,
+					SkipQuestStatusCheck = true,
+					SkipActivatedTraitUpdate = true,
+				})
+				CurrentRun.Hero.SlottedSpell = DeepCopyTable(stateData.Hex)
+			else
+				AddTraitToHero({
+					TraitName = stateData.Hex,
+					SkipNewTraitHighlight = true,
+					SkipQuestStatusCheck = true,
+					SkipActivatedTraitUpdate = true,
+				})
+				local spellName = stateData.Hex:gsub("Trait", "")
+				spellName = spellName:gsub("Spell", "")
+				if SpellData[spellName] then
+					CurrentRun.Hero.SlottedSpell = DeepCopyTable(SpellData[spellName])
+					CurrentRun.Hero.SlottedSpell.Talents = DeepCopyTable(CreateTalentTree(SpellData[spellName]))
+				end
+			end
 		end
 		for _, traitData in pairs(stateData.MetaUpgrades) do
 			AddTraitToHero({
@@ -849,6 +869,15 @@ function mod.LoadState(newRun, slotIndex)
 				CustomMultiplier = traitData.CustomMultiplier,
 				SourceName = traitData.SourceName,
 			})
+		end
+		
+		if stateData.LastStands ~= nil then
+			CurrentRun.Hero.LastStands = DeepCopyTable(stateData.LastStands)
+		else
+			InitHeroLastStands(CurrentRun.Hero)
+		end
+		if UpdateLifePips then
+			UpdateLifePips(CurrentRun.Hero)
 		end
 	end
 	


### PR DESCRIPTION
This PR expands the **Save State/Layout** function, to enable multiple save slots. Now user can save current state into different slot and load state from any slot. 

PR also included a seamless migration script from the old `data.SavedState` to a new `data.SavedStates` table struct so users won't lose their old data.